### PR TITLE
Reduce output to the console from R script

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - r-base=4.0.5
   - r-optparse=1.7.1
   - r-readr=2.0.2
+  - r-logger=0.2.2
   - r-lubridate=1.8.0
   - r-tidyverse=1.3.1
   - r-dplyr=1.0.7


### PR DESCRIPTION
Use a logging package with default to WARN level and above (get more output using --verbose). Sprinkle suppressMessages around to work around columns not being specificed when doing dplyr joins (please just specify by = <columns> for each of these so this hack isn't necessary!).